### PR TITLE
インストール手順をpipからuvに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ cdk.out/
 .cdk.staging/
 cdk.context.json
 .DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@
 git clone https://github.com/yourusername/aws-pricing-calculator-merger.git
 cd aws-pricing-calculator-merger
 
-# 仮想環境の作成（任意）
-python -m venv venv
-source venv/bin/activate  # Windowsの場合: venv\Scripts\activate
+# uv がインストールされていない場合はインストール
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 仮想環境の作成と依存パッケージのインストール
+uv venv  # 仮想環境を作成
+source .venv/bin/activate  # Windowsの場合: .venv\Scripts\activate
 
 # 依存パッケージのインストール
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 ```
 
 ### アプリケーションの実行

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,27 +31,34 @@ git clone https://github.com/gacuo/aws-pricing-calculator-merger.git
 cd aws-pricing-calculator-merger
 ```
 
-2. 仮想環境の作成と有効化
+2. uv のインストール
 
 ```bash
-python -m venv venv
-source venv/bin/activate  # Windowsの場合: venv\Scripts\activate
+# uv がインストールされていない場合はインストール
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-3. 開発用依存パッケージのインストール
+3. 仮想環境の作成と有効化
 
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
+uv venv
+source .venv/bin/activate  # Windowsの場合: .venv\Scripts\activate
 ```
 
-4. pre-commitフックのインストール
+4. 開発用依存パッケージのインストール
+
+```bash
+uv pip install -r requirements.txt
+uv pip install -r requirements-dev.txt
+```
+
+5. pre-commitフックのインストール
 
 ```bash
 pre-commit install
 ```
 
-5. アプリケーションの実行
+6. アプリケーションの実行
 
 ```bash
 python app.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,13 +67,16 @@ aws-pricing-calculator-merger/
 git clone https://github.com/gacuo/aws-pricing-calculator-merger.git
 cd aws-pricing-calculator-merger
 
+# uv がインストールされていない場合はインストール
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
 # 仮想環境の作成と有効化
-python -m venv venv
-source venv/bin/activate  # Windowsの場合: venv\Scripts\activate
+uv venv
+source .venv/bin/activate  # Windowsの場合: .venv\Scripts\activate
 
 # 依存パッケージのインストール
-pip install -r requirements.txt
-pip install -r requirements-dev.txt  # 開発用パッケージ
+uv pip install -r requirements.txt
+uv pip install -r requirements-dev.txt  # 開発用パッケージ
 
 # アプリケーションの実行
 python app.py

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,14 @@
+# uv設定ファイル
+
+[venv]
+# 仮想環境の作成先を.venvディレクトリに設定
+venv-path = ".venv"
+
+[python]
+# デフォルトで使用するPythonバージョン
+python-path = "python3.10"
+
+[pip]
+# インストール時のオプション
+quiet = false
+index-url = "https://pypi.org/simple"


### PR DESCRIPTION
## 概要
Issue #4 の対応として、インストール手順をpipからuvに変更しました。

## 変更内容
- READMEのインストール手順を更新
- docs/README.mdのインストール手順を更新
- docs/DEVELOPMENT.mdの開発環境セットアップ手順を更新
- uv.toml設定ファイルを追加
- .gitignoreに.venv/ディレクトリを追加

## なぜこの変更が必要か
uvを使用することで、Pythonのバージョン管理をディレクトリ単位で行えるようになり、環境管理が容易になります。
また、uvはpipよりも高速で、依存関係の解決も優れています。

## 関連Issue
Closes #4

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1751886109854 -->

---

**Open in Web UI**: https://d3fdwcze17tei3.cloudfront.net/sessions/webapp-1751886109854